### PR TITLE
fix: improved html attribute parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preact-parser",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "repository": "git@github.com:jahilldev/preact-parser.git",
   "author": "James Hill <contact@jameshill.dev>",
   "license": "MIT",

--- a/src/model.ts
+++ b/src/model.ts
@@ -32,7 +32,7 @@ enum NodeType {
  * -------------------------------- */
 
 const htmlRegex = /<!--[\s\S]*?-->|<(\/?)([a-zA-Z][-.:0-9_a-zA-Z]*)((?:\s+[^>]*?(?:(?:'[^']*')|(?:"[^"]*"))?)*)\s*(\/?)>/g;
-const attrRegex = /(\S+)\s*=\s*(\"?)([^"]*)(\2|\s|$)/gi;
+const attrRegex = /([a-zA-Z\<\>//]){0}\s(?<key>[a-zA-Z]+)=?("(?<value>[A-Za-z\d\s?%&=;_:.\-\/\\%]*)")?/gi;
 const frameflag = 'documentfragmentcontainer';
 
 /* -----------------------------------

--- a/src/model.ts
+++ b/src/model.ts
@@ -32,7 +32,7 @@ enum NodeType {
  * -------------------------------- */
 
 const htmlRegex = /<!--[\s\S]*?-->|<(\/?)([a-zA-Z][-.:0-9_a-zA-Z]*)((?:\s+[^>]*?(?:(?:'[^']*')|(?:"[^"]*"))?)*)\s*(\/?)>/g;
-const attrRegex = /([a-zA-Z\<\>//]){0}\s(?<key>[a-zA-Z]+)=?("(?<value>[A-Za-z\d\s?%&=;_:.\-\/\\%]*)")?/gi;
+const attrRegex = /([a-zA-Z\<\>//]){0}\s(?<key>[a-zA-Z|-]+)=?("(?<value>[A-Za-z\d\s?%&=;_:.\-\/\\%]*)")?/gi;
 const frameflag = 'documentfragmentcontainer';
 
 /* -----------------------------------

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -160,12 +160,11 @@ function parseAttributes(attributes: string) {
   const result = [];
 
   for (let match; (match = attrRegex.exec(attributes)); ) {
-    const { 1: key, 3: value } = match;
-    const isQuoted = value[0] === `'` || value[0] === `"`;
+    const { key, value } = match.groups;
 
     const attribute = {
       name: key.toLowerCase(),
-      value: isQuoted ? value.slice(1, value.length - 1) : value,
+      value,
     };
 
     result.push(attribute);

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -9,9 +9,12 @@ import { parse } from '../src/index';
  * -------------------------------- */
 
 const testCaption = 'testCaption';
+const testId = 'testId';
 const testTitle = 'testTitle';
 const testWord = 'testWord';
 const testText = 'Lorem ipsum dolor sit amet';
+const testClass = 'testClass';
+const testCss = '.image { background: orange; }';
 const testUrl = 'https://jameshill.dev/?option=123456&section=top';
 const testImage = 'https://via.placeholder.com/150';
 const testSentence = `<p><strong>${testWord}</strong> <em>${testWord}</em> &nbsp; ${testWord}?</p>`;
@@ -19,17 +22,17 @@ const testAnchor = `<a href="${testUrl}">${testWord}</a>`;
 
 const testHtml = `
   <!-- some comment -->
-  <article title="Article" id="first" class="container" data-article="1">
+  <article title="${testTitle}" id="${testId}" class="${testClass}" data-article="1">
     <style data-theme>
-      .image { background: orange; }
+      ${testCss}
     </style>
     <h2>${testTitle}</h2>
-    <figure class="image" title="Image">
+    <figure class="image" title="${testTitle}">
       <img src="${testImage}" alt="Placeholder" />
       <figcaption>${testCaption}</figcaption>
     </figure>
     <!-- some comment -->
-    <p id="text" class="text grey">
+    <p id="${testId}" class="text grey">
       <span>Intro:</span> ${testText}
       <br />
       <a href="${testUrl}" target="_blank" rel="noopener">
@@ -68,8 +71,22 @@ describe('parse()', () => {
       const instance = mount(result);
 
       expect(instance.find('article').exists()).toEqual(true);
+      expect(instance.find('style').text().trim()).toEqual(testCss);
       expect(instance.find('h2').text()).toEqual(testTitle);
       expect(instance.find('img').prop('src')).toEqual(testImage);
+
+      expect(instance.find('article').props()).toEqual({
+        className: testClass,
+        'data-article': '1',
+        id: testId,
+        title: testTitle,
+      });
+
+      expect(instance.find('a').props()).toEqual({
+        href: testUrl,
+        rel: 'noopener',
+        target: '_blank',
+      });
     });
 
     it('can be used within JSX and Preact components', () => {
@@ -118,8 +135,22 @@ describe('parse()', () => {
       const instance = mount(result as any);
 
       expect(instance.find('article').exists()).toEqual(true);
+      expect(instance.find('style').text().trim()).toEqual(testCss);
       expect(instance.find('h2').text()).toEqual(testTitle);
       expect(instance.find('img').prop('src')).toEqual(testImage);
+
+      expect(instance.find('article').props()).toEqual({
+        className: testClass,
+        'data-article': '1',
+        id: testId,
+        title: testTitle,
+      });
+
+      expect(instance.find('a').props()).toEqual({
+        href: testUrl,
+        rel: 'noopener',
+        target: '_blank',
+      });
     });
 
     it('can be used within JSX and Preact components', () => {

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -12,9 +12,10 @@ const testCaption = 'testCaption';
 const testTitle = 'testTitle';
 const testWord = 'testWord';
 const testText = 'Lorem ipsum dolor sit amet';
+const testUrl = 'https://jameshill.dev/?option=123456&section=top';
 const testImage = 'https://via.placeholder.com/150';
-
 const testSentence = `<p><strong>${testWord}</strong> <em>${testWord}</em> &nbsp; ${testWord}?</p>`;
+const testAnchor = `<a href="${testUrl}">${testWord}</a>`;
 
 const testHtml = `
   <!-- some comment -->
@@ -31,7 +32,7 @@ const testHtml = `
     <p id="text" class="text grey">
       <span>Intro:</span> ${testText}
       <br />
-      <a href="/" target="_blank" rel="noopener">
+      <a href="${testUrl}" target="_blank" rel="noopener">
         Go <em class="accent">back</em>
       </a>
     </p>
@@ -126,6 +127,14 @@ describe('parse()', () => {
 
       expect(instance.find('article').exists()).toEqual(true);
       expect(instance.find('h2').text()).toEqual(testTitle);
+    });
+
+    it('parses anchor href attributes correctly', () => {
+      const result = parse(testAnchor) as JSX.Element;
+      const instance = mount(result as any);
+
+      expect(instance.find('a').exists()).toEqual(true);
+      expect(instance.find('a').prop('href')).toEqual(testUrl);
     });
 
     it('preserves word spacing if present', () => {


### PR DESCRIPTION
- Improved HTML attribute string regex to handle anchor `href` values containing `=`
- Swapped index based match group with named
- Improved test cases to better cover variations
- Correctly handles `data-*` attributes (or other hyphenated keys)